### PR TITLE
make sure variables in example are FastKeys

### DIFF
--- a/fastkey_test.go
+++ b/fastkey_test.go
@@ -13,9 +13,8 @@ func (a *FastType) Less(b interface{}) bool {
 	mb := b.(*FastType)
 	return (a.a + a.b) < (mb.a + mb.b)
 }
-func (*FastType) Score(i interface{}) float64 {
-	// Score(i) increase monotonically with increasing key value.
-	m := i.(*FastType)
+// Score implements the FastKey interface.
+func (m *FastType) Score() float64 {
 	return float64(m.a + m.b)
 }
 
@@ -23,7 +22,7 @@ func (*FastType) Score(i interface{}) float64 {
 //
 func ExampleFastKey() {
 	keys := []FastType{{1, 2}, {5, 6}, {3, 4}}
-	s := New().Insert(&keys[0], 1).Insert(&keys[1], 2).Insert(&keys[2], 3)
+	s := New().Insert(FastKey(&keys[0]), 1).Insert(FastKey(&keys[1]), 2).Insert(FastKey(&keys[2]), 3)
 	fmt.Print(s)
 	// Output: {&{1 2}:1 &{3 4}:3 &{5 6}:2}
 }


### PR DESCRIPTION
The example for the interface FastKey seems to be wrong, should the correct implementation and example be like this?
